### PR TITLE
Add optional TwelveLabs Marengo + Pegasus backends

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,52 @@ python vidrag_pipeline.py
 4. The final prompt may suit your model (line #366).
 ```
 
+## ☁️ Optional: TwelveLabs (Marengo + Pegasus)
+
+The pipeline ships an **opt-in** TwelveLabs backend in addition to the default
+fully open-source path. It is disabled by default and changes nothing unless you
+set the environment variables below, so the original behavior is preserved.
+
+- **Marengo** replaces the local Contriever retriever with hosted multimodal
+  (512-dim) embeddings for the OCR/ASR RAG step — same `retrieve_documents_with_dynamic`
+  signature, same FAISS range search, no local embedding model to load.
+- **Pegasus** replaces the local LLaVA-Video model for the final answer step —
+  it reads the source video server-side, so you don't need the LVLM weights or a
+  GPU to produce an answer.
+
+Install the SDK and set a key (free tier at https://twelvelabs.io):
+
+```
+pip install twelvelabs
+export TWELVELABS_API_KEY=<your-key>
+```
+
+Marengo retrieval (drop-in for Contriever):
+
+```
+export USE_TWELVELABS_RETRIEVER=1
+python vidrag_pipeline.py
+```
+
+Pegasus answering (point it at the source video):
+
+```
+export USE_PEGASUS=1
+export TWELVELABS_VIDEO_URL=https://.../video.mp4   # or TWELVELABS_VIDEO_ID / TWELVELABS_ASSET_ID
+python vidrag_pipeline.py
+```
+
+Both flags are independent and can be combined. Optional overrides:
+`TWELVELABS_EMBED_MODEL` (default `marengo3.0`), `TWELVELABS_ANALYZE_MODEL`
+(default `pegasus1.5`), `TWELVELABS_MAX_TOKENS` (default `2048`).
+
+A focused test (the network part is skipped without a key) lives at
+`vidrag_pipeline/tools/test_twelvelabs.py`:
+
+```
+python tools/test_twelvelabs.py
+```
+
 ## ✏️ Citation
 
 If you find our paper and code useful in your research, please consider giving a star ⭐ and citation 📝:

--- a/vidrag_pipeline/tools/pegasus_inference.py
+++ b/vidrag_pipeline/tools/pegasus_inference.py
@@ -1,0 +1,74 @@
+# TwelveLabs Pegasus-backed video understanding.
+#
+# Drop-in replacement for the local `llava_inference(qs, video)` in
+# `vidrag_pipeline.py`. Pegasus is a video-language model served by TwelveLabs,
+# so the heavy LLaVA-Video weights are not needed locally: the prompt (already
+# augmented with the retrieved OCR / ASR / DET auxiliary texts) is sent to
+# Pegasus together with the source video, and the generated answer is returned.
+#
+# Opt-in only: nothing imports this unless `USE_PEGASUS=1` is set in
+# `vidrag_pipeline.py`. Requires `pip install twelvelabs` and the environment
+# variable `TWELVELABS_API_KEY` (grab a free key at https://twelvelabs.io).
+
+import os
+from twelvelabs import TwelveLabs
+
+PEGASUS_MODEL = os.getenv("TWELVELABS_ANALYZE_MODEL", "pegasus1.5")
+
+_client = None
+
+
+def _get_client():
+    global _client
+    if _client is None:
+        api_key = os.getenv("TWELVELABS_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "TWELVELABS_API_KEY is not set. Get a free key at https://twelvelabs.io"
+            )
+        _client = TwelveLabs(api_key=api_key)
+    return _client
+
+
+def pegasus_inference(qs, video):
+    """Pegasus-backed twin of `vidrag_pipeline.llava_inference`.
+
+    `qs` is the (RAG-augmented) prompt. `video` selects the source clip and is
+    one of:
+      - a `{"url": "https://..."}` dict for a publicly reachable video URL,
+      - a `{"video_id": "<indexed-id>"}` dict for a video already indexed in
+        TwelveLabs,
+      - a `{"asset_id": "<asset-id>"}` dict for an uploaded asset,
+      - or `None`, which sends a text-only prompt (mirrors `llava_inference`'s
+        text-only branch used for the chain-of-thought retrieval step).
+    """
+    client = _get_client()
+    max_tokens = int(os.getenv("TWELVELABS_MAX_TOKENS", "2048"))
+
+    if video is None:
+        # Text-only step (e.g. the retrieve-request JSON generation). Pegasus
+        # always needs a video, so callers should keep using their text LLM for
+        # this branch; we surface a clear error rather than guess.
+        raise ValueError(
+            "pegasus_inference requires a video context; use a text model for "
+            "the video-less chain-of-thought step."
+        )
+
+    if "url" in video:
+        kwargs = {"video": {"type": "url", "url": video["url"]}}
+    elif "asset_id" in video:
+        kwargs = {"video": {"type": "asset_id", "asset_id": video["asset_id"]}}
+    elif "video_id" in video:
+        kwargs = {"video_id": video["video_id"]}
+    else:
+        raise ValueError(
+            "video must contain one of 'url', 'asset_id', or 'video_id'."
+        )
+
+    resp = client.analyze(
+        model_name=PEGASUS_MODEL,
+        prompt=qs,
+        max_tokens=max_tokens,
+        **kwargs,
+    )
+    return resp.data.strip() if isinstance(resp.data, str) else resp.data

--- a/vidrag_pipeline/tools/rag_retriever_twelvelabs.py
+++ b/vidrag_pipeline/tools/rag_retriever_twelvelabs.py
@@ -1,0 +1,78 @@
+# TwelveLabs Marengo-backed retriever.
+#
+# Drop-in replacement for `retrieve_documents_with_dynamic` in
+# `rag_retriever_dynamic.py`. Instead of the local Contriever model, it embeds
+# the auxiliary texts (OCR / ASR) and the query with TwelveLabs Marengo
+# (512-dim multimodal embeddings) and keeps the same FAISS inner-product
+# range-search retrieval, so the rest of the pipeline is unchanged.
+#
+# Opt-in only: nothing imports this unless `USE_TWELVELABS_RETRIEVER=1` is set
+# in `vidrag_pipeline.py`. Requires `pip install twelvelabs` and the
+# environment variable `TWELVELABS_API_KEY` (grab a free key at
+# https://twelvelabs.io).
+
+import os
+import numpy as np
+import faiss
+from twelvelabs import TwelveLabs
+
+# Marengo text embeddings are 512-dim; embedding the OCR/ASR docs and the query
+# in the same space lets us reuse the existing FAISS retrieval unchanged.
+MARENGO_MODEL = os.getenv("TWELVELABS_EMBED_MODEL", "marengo3.0")
+
+_client = None
+
+
+def _get_client():
+    global _client
+    if _client is None:
+        api_key = os.getenv("TWELVELABS_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "TWELVELABS_API_KEY is not set. Get a free key at https://twelvelabs.io"
+            )
+        _client = TwelveLabs(api_key=api_key)
+    return _client
+
+
+def text_to_vector(text):
+    """Embed a single string with Marengo, returning a 512-dim numpy vector."""
+    resp = _get_client().embed.create(model_name=MARENGO_MODEL, text=text)
+    return np.array(resp.text_embedding.segments[0].float_, dtype=np.float64)
+
+
+def retrieve_documents_with_dynamic(documents, queries, threshold=0.4):
+    """Marengo-backed twin of `rag_retriever_dynamic.retrieve_documents_with_dynamic`.
+
+    Same signature, same return value `(top_documents, idx)`, so it can be
+    swapped in without touching the calling code.
+    """
+    if isinstance(queries, list):
+        query_vectors = np.array([text_to_vector(query) for query in queries])
+        average_query_vector = np.mean(query_vectors, axis=0)
+        query_vector = average_query_vector / np.linalg.norm(average_query_vector)
+        query_vector = query_vector.reshape(1, -1)
+    else:
+        query_vector = text_to_vector(queries)
+        query_vector = query_vector / np.linalg.norm(query_vector)
+        query_vector = query_vector.reshape(1, -1)
+
+    document_vectors = np.array([text_to_vector(doc) for doc in documents])
+    document_vectors = document_vectors / np.linalg.norm(document_vectors, axis=1, keepdims=True)
+    dimension = document_vectors.shape[1]
+
+    index = faiss.IndexFlatIP(dimension)
+    index.add(document_vectors)
+    lims, D, I = index.range_search(query_vector, threshold)
+    start = lims[0]
+    end = lims[1]
+    I = I[start:end]
+
+    if len(I) == 0:
+        top_documents = []
+        idx = []
+    else:
+        idx = I.tolist()
+        top_documents = [documents[i] for i in idx]
+
+    return top_documents, idx

--- a/vidrag_pipeline/tools/test_twelvelabs.py
+++ b/vidrag_pipeline/tools/test_twelvelabs.py
@@ -1,0 +1,52 @@
+# Focused tests for the TwelveLabs integration. No test framework needed:
+#   python tools/test_twelvelabs.py
+#
+# - test_retriever_logic: no network. Stubs Marengo embeddings so the FAISS
+#   range-search retrieval is exercised deterministically.
+# - test_marengo_live: skipped unless TWELVELABS_API_KEY is set; asserts a real
+#   512-dim Marengo text embedding comes back.
+
+import os
+import sys
+
+import numpy as np
+
+import rag_retriever_twelvelabs as r
+
+
+def test_retriever_logic():
+    # Three docs in a tiny embedding space; the query points at doc 0/1.
+    space = {
+        "cat on a mat": [1.0, 0.0, 0.0],
+        "kitten on a rug": [0.9, 0.1, 0.0],
+        "stock market crash": [0.0, 0.0, 1.0],
+        "house cats and rugs": [0.95, 0.05, 0.0],  # the query text
+    }
+    r.text_to_vector = lambda t: np.array(space[t], dtype=np.float64)
+
+    docs = ["cat on a mat", "kitten on a rug", "stock market crash"]
+    top, idx = r.retrieve_documents_with_dynamic(docs, ["house cats and rugs"], threshold=0.8)
+
+    assert "stock market crash" not in top, top
+    assert "cat on a mat" in top and "kitten on a rug" in top, top
+    assert set(idx) == {0, 1}, idx
+    print("test_retriever_logic: ok")
+
+
+def test_marengo_live():
+    if not os.getenv("TWELVELABS_API_KEY"):
+        print("test_marengo_live: skipped (no TWELVELABS_API_KEY)")
+        return
+    # Force a fresh client (the module caches a stub-friendly one).
+    r._client = None
+    vec = r.text_to_vector("a person walking a dog in a park")
+    assert vec.shape == (512,), vec.shape
+    print("test_marengo_live: ok (512-dim)")
+
+
+if __name__ == "__main__":
+    # Live test first: test_retriever_logic monkeypatches text_to_vector.
+    test_marengo_live()
+    test_retriever_logic()
+    print("all tests passed")
+    sys.exit(0)

--- a/vidrag_pipeline/vidrag_pipeline.py
+++ b/vidrag_pipeline/vidrag_pipeline.py
@@ -12,7 +12,14 @@ import json
 from tqdm import tqdm
 import os
 import easyocr
-from tools.rag_retriever_dynamic import retrieve_documents_with_dynamic
+# Retriever backend: by default the local Contriever model. Set
+# USE_TWELVELABS_RETRIEVER=1 (and TWELVELABS_API_KEY) to retrieve with
+# TwelveLabs Marengo (512-dim multimodal embeddings) instead. Both expose the
+# same retrieve_documents_with_dynamic(documents, queries, threshold) signature.
+if os.getenv("USE_TWELVELABS_RETRIEVER") == "1":
+    from tools.rag_retriever_twelvelabs import retrieve_documents_with_dynamic
+else:
+    from tools.rag_retriever_dynamic import retrieve_documents_with_dynamic
 import re
 import ast
 import socket
@@ -365,5 +372,25 @@ if USE_OCR and len(ocr_docs) > 0:
     qs += "\nVideo OCR information (given in chronological order of the video): " + "; ".join(ocr_docs)
 qs += "Select the best answer to the following multiple-choice question based on the video and the information (if given). Respond with only the letter (A, B, C, or D) of the correct option. Question: " + question  # you can change this prompt
 
-res = llava_inference(qs, video)
+# Final answer: by default the local LLaVA-Video model. Set USE_PEGASUS=1 (and
+# TWELVELABS_API_KEY) to answer with the TwelveLabs Pegasus video-language
+# model instead. Pegasus reads the video server-side, so point it at the source
+# clip via TWELVELABS_VIDEO_URL (a public URL) or TWELVELABS_VIDEO_ID / _ASSET_ID
+# for media already in TwelveLabs. The RAG-augmented prompt `qs` is unchanged.
+if os.getenv("USE_PEGASUS") == "1":
+    from tools.pegasus_inference import pegasus_inference
+    if os.getenv("TWELVELABS_VIDEO_URL"):
+        pegasus_video = {"url": os.environ["TWELVELABS_VIDEO_URL"]}
+    elif os.getenv("TWELVELABS_VIDEO_ID"):
+        pegasus_video = {"video_id": os.environ["TWELVELABS_VIDEO_ID"]}
+    elif os.getenv("TWELVELABS_ASSET_ID"):
+        pegasus_video = {"asset_id": os.environ["TWELVELABS_ASSET_ID"]}
+    else:
+        raise RuntimeError(
+            "USE_PEGASUS=1 requires TWELVELABS_VIDEO_URL, TWELVELABS_VIDEO_ID, "
+            "or TWELVELABS_ASSET_ID so Pegasus can read the source video."
+        )
+    res = pegasus_inference(qs, pegasus_video)
+else:
+    res = llava_inference(qs, video)
 print(res)


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This adds an **opt-in** TwelveLabs backend for two stages of the Video-RAG pipeline. It is fully non-breaking: nothing changes unless you set the new environment variables, and the default fully open-source path (Contriever + LLaVA-Video) is untouched.

**What it adds**
- `vidrag_pipeline/tools/rag_retriever_twelvelabs.py` — a drop-in twin of `retrieve_documents_with_dynamic` that embeds the OCR/ASR docs and the query with **Marengo** (512-dim multimodal embeddings) instead of the local Contriever model. Same signature, same FAISS inner-product range search, so the calling code is unchanged.
- `vidrag_pipeline/tools/pegasus_inference.py` — a drop-in twin of `llava_inference` that answers with the **Pegasus** video-language model. Pegasus reads the source video server-side, so the LVLM weights and a GPU aren't required for the final answer step.
- Wiring in `vidrag_pipeline.py`: `USE_TWELVELABS_RETRIEVER=1` swaps the retriever import; `USE_PEGASUS=1` (+ `TWELVELABS_VIDEO_URL` / `_VIDEO_ID` / `_ASSET_ID`) swaps the final inference. Both default off.
- readme section documenting setup and the env flags.

**Why it helps this project**
Video-RAG's two heaviest local dependencies are the embedding model for retrieval and the LVLM for answering. These optional backends let users run the same RAG pipeline without loading either locally — useful for low-resource setups or quick experiments — while keeping the existing open-source path as the default.

**Opt-in / non-breaking**
Both flags are off by default; with no env vars set, behavior is identical to before. The backends mirror the existing function signatures exactly.

**How it was tested**
- `vidrag_pipeline/tools/test_twelvelabs.py`: a no-network unit test exercises the FAISS retrieval with stubbed embeddings, and a key-gated live test asserts a real Marengo text embedding is 512-dim. Both pass locally (`python tools/test_twelvelabs.py`).
- Verified the Pegasus url/video_id/asset_id request wiring with a mocked client (no-network). A full Pegasus answer run is wiring-verified; end-to-end timing depends on server-side video processing.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.